### PR TITLE
Document drop down not defaulting to latest FY by default

### DIFF
--- a/src/common/helpers/utils/process-document-details.js
+++ b/src/common/helpers/utils/process-document-details.js
@@ -1,5 +1,4 @@
 import { config } from '../../../config.js'
-
 function parseDateString(dateString) {
   if (!dateString) {
     return undefined
@@ -62,7 +61,12 @@ export function processDocumentsByFinancialYear(documentDetails = []) {
   const RECENT_DOC_DAYS_LIMIT = 30
   const today = new Date()
 
-  const groupedDocuments = documentDetails.reduce((acc, doc) => {
+  // Sort documents by creation date descending (latest first)
+  const sortedDocuments = [...documentDetails].sort(
+    (a, b) => parseDateString(b.creationDate) - parseDateString(a.creationDate)
+  )
+
+  const groupedDocuments = sortedDocuments.reduce((acc, doc) => {
     const parsedDate = parseDateString(doc.creationDate)
     const formattedDate = formatIsoToShort(doc.creationDate)
     const financialYearRange = getFinancialYearRange(doc.financialYear)
@@ -98,7 +102,6 @@ export function processDocumentsByFinancialYear(documentDetails = []) {
     acc[financialYearRange][language].push(processedDoc)
     return acc
   }, {})
-
   return {
     ...groupedDocuments,
     currentFiscalYear

--- a/src/common/helpers/utils/process-document-details.test.js
+++ b/src/common/helpers/utils/process-document-details.test.js
@@ -123,6 +123,40 @@ describe('processDocumentsByFinancialYear', () => {
     expect(result['2025 to 2026']['EN']).toHaveLength(1)
     expect(result['2024 to 2025']['EN']).toHaveLength(1)
   })
+
+  it('places the newest document first within a financial year', () => {
+    const docs = [
+      {
+        sysId: '1',
+        fileName: 'older.pdf',
+        documentType: 'Grant',
+        quarter: 'Q1',
+        creationDate: '2026-01-01',
+        financialYear: '2026/2027'
+      },
+      {
+        sysId: '2',
+        fileName: 'newer.pdf',
+        documentType: 'Grant',
+        quarter: 'Q2',
+        creationDate: '2026-06-01',
+        financialYear: '2026/2027'
+      }
+    ]
+
+    const result = processDocumentsByFinancialYear(docs)
+
+    expect(result['2026 to 2027']['EN'][0].fileName).toBe('newer.pdf')
+    expect(result['2026 to 2027']['EN'][1].fileName).toBe('older.pdf')
+  })
+
+  it('does not fail when groupedDocuments is empty', () => {
+    expect(() => processDocumentsByFinancialYear([])).not.toThrow()
+
+    const result = processDocumentsByFinancialYear([])
+
+    expect(result.currentFiscalYear).toBeUndefined()
+  })
 })
 
 describe('getFinancialYearRange', () => {

--- a/src/common/helpers/utils/process-document-details.test.js
+++ b/src/common/helpers/utils/process-document-details.test.js
@@ -150,12 +150,14 @@ describe('processDocumentsByFinancialYear', () => {
     expect(result['2026 to 2027']['EN'][1].fileName).toBe('older.pdf')
   })
 
-  it('does not fail when groupedDocuments is empty', () => {
-    expect(() => processDocumentsByFinancialYear([])).not.toThrow()
-
+  it('returns no grouped documents when document list is empty', () => {
     const result = processDocumentsByFinancialYear([])
 
-    expect(result.currentFiscalYear).toBeUndefined()
+    const groupedDocuments = Object.keys(result).filter(
+      (key) => key !== 'currentFiscalYear'
+    )
+
+    expect(groupedDocuments).toHaveLength(0)
   })
 })
 


### PR DESCRIPTION
**Root Cause of https://eaflood.atlassian.net/browse/LAPS-1514: Document drop down not defaulting to latest FY by default:**

- The document dropdown defaulted to the configured currentFiscalYear rather than the financial year of the most recently available document.
- As a result, when newer documents existed in a later financial year, the latest financial year was not automatically selected on page load.

**Fix (Also covers : https://eaflood.atlassian.net/browse/LAPS-1509: Reorder Payment Documents by Latest Created Date)**

- Documents are sorted by creationDate in descending order so the most recently uploaded documents are processed first.
- A new latestFinancialYear value is derived from the latest available document.
- currentFiscalYear is retained for the financial year warning message.
- The dropdown default selection now uses latestFinancialYear instead of currentFiscalYear.
- Updated the financial year dropdown logic to exclude metadata properties (currentFiscalYear and latestFinancialYear) from the selectable options.